### PR TITLE
Replace repo URL when it contains version string

### DIFF
--- a/debian11to12/upgrader.py
+++ b/debian11to12/upgrader.py
@@ -92,6 +92,14 @@ class Debian11to12Upgrader(DistUpgrader):
             ],
             "Switch repositories": [
                 actions.SetupDebianRepositories("bullseye", "bookworm"),
+                actions.ReplaceAptReposRegexp(
+                    r'(http|https)://([^/]+)/(.*\b)11\.11(\b.*)',
+                    '\g<1>://\g<2>/\g<3>12.7\g<4>',
+                ),
+                actions.ReplaceAptReposRegexp(
+                    r'(http|https)://([^/]+)/(.*\b)11\(\b.*)',
+                    '\g<1>://\g<2>/\g<3>12\g<4>',
+                ),
                 actions.SwitchPleskRepositories(to_os_version="12"),
             ],
             "Pre-install packages": [


### PR DESCRIPTION
Fixes PAUX-6369 Invalid APT sources produced by source switch procedure