### PR TITLE
Substitude 11 to 12 only for debian or debian-testing repositories

### DIFF
--- a/debian11to12/upgrader.py
+++ b/debian11to12/upgrader.py
@@ -94,8 +94,8 @@ class Debian11to12Upgrader(DistUpgrader):
             "Switch repositories": [
                 actions.AdoptAptRepositoriesUbuntu([
                     strings.create_replace_string_function('bullseye', 'bookworm'),
-                    strings.create_replace_regexp_function(r'(http|https)://([^/]+)/(.*\b)11\.11(\b.*)', '\g<1>://\g<2>/\g<3>12.7\g<4>'),
-                    strings.create_replace_regexp_function(r'(http|https)://([^/]+)/(.*\b)11(\b.*)', '\g<1>://\g<2>/\g<3>12\g<4>'),
+                    strings.create_replace_regexp_function(r'(http|https)://([^/]+)/(\b.*)(debian|debian-testing)/11\.11(\b.*)', '\g<1>://\g<2>/\g<3>\g<4>/12.7\g<5>'),
+                    strings.create_replace_regexp_function(r'(http|https)://([^/]+)/(\b.*)(debian|debian-testing)/11(\b.*)', '\g<1>://\g<2>/\g<3>\g<4>/12\g<5>'),
                     ], name="modify apt repositories to new OS"
                 ),
                 actions.SwitchPleskRepositories(to_os_version="12"),


### PR DESCRIPTION
Because we need to avoid the substitution for mariadb 11 for example